### PR TITLE
Add hotfix for Terraform "count" issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
   assume_policy = var.assume_policy != null ? var.assume_policy : data.aws_iam_policy_document.default.json
+  create_policy = var.force_create_policy != null ? (var.force_create_policy ? 1 : 0): (var.role_policy != "" ? 1 : 0)
 }
 
 provider "aws" {}
@@ -23,7 +24,7 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_iam_role_policy" "default" {
-  count  = var.role_policy != "" ? 1 : 0
+  count  = local.create_policy
   name   = "${var.name}${var.postfix ? "Policy" : ""}"
   role   = aws_iam_role.default.id
   policy = var.role_policy

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "assume_policy" {
   description = "The assume policy to attach to the role"
 }
 
+variable "force_create_policy" {
+  type        = bool
+  default     = null
+  description = "Overrule whether the role policy has to be created."
+}
+
 variable "principal_type" {
   type        = string
   default     = ""


### PR DESCRIPTION
This PR adds the option to explicitly create the Role Policy (or not), whether a policy is given or not. This is optional and should only be used to a (possible) issue that Terraform cannot determine a `count` value:

```Error: Invalid count argument

  on .terraform/modules/mx001un_cb_brewery.iot-core-to-s3.iot_topic_role_firehose/main.tf line 26, in resource "aws_iam_role_policy" "default":
  26:   count  = var.role_policy != "" ? 1 : 0

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```

When this error occurs depends on the explicit setup with modules, data resources and variables and therefor does not always occur.

Normally, a Policy resource is created if a policy document is specified. Normally we specify the policy in a data resource. If there is no state file present, Terraform cannot always determine the value of the data resource (because there is no state yet) and fails the plan.

In this specific situation this can be fixed by "hardcoding" the check if the policy has to be created, basically "helping" terraform with the plan... (See Issue links below for more (detailed) context)

**Example usage**
```
module "my_role" {
  providers             = { aws = aws }
  source                = "github.com/schubergphilis/terraform-aws-mcaf-role?ref=v0.1.6"
  name                  = "Test"
  role_policy           = data.aws_iam_policy_document.redshift_spectrum_policy.json
  force_create_policy   = true 
}
```
The `force_create_policy` explicitly tells Terraform to create the role, removing the "cannot be determined" error


**Issues:**
* https://github.com/hashicorp/terraform/issues/17034
* https://github.com/hashicorp/terraform/issues/21047