### PR TITLE
breaking: changed `policy_arns` variable from list(string) to list(map)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,8 +32,8 @@ resource "aws_iam_role_policy" "default" {
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  for_each = var.policy_arns
+  for_each = length(var.policy_arns) != 0 ? { for v in var.policy_arns : v.description => v } : {}
 
   role       = aws_iam_role.default.name
-  policy_arn = each.value
+  policy_arn = each.value.arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,10 @@ variable "principal_identifiers" {
 }
 
 variable "policy_arns" {
-  type        = set(string)
+  type = list(object({
+    description = string
+    arn         = string
+  }))
   default     = []
   description = "A set of policy ARNs to attach to the user"
 }
@@ -62,7 +65,6 @@ variable "role_policy" {
   default     = null
   description = "The IAM policy to attach to the role"
 }
-
 
 variable "tags" {
   type        = map(string)


### PR DESCRIPTION
Faced the same https://github.com/schubergphilis/terraform-aws-mcaf-aurora/pull/53 as the Aurora module so converted the variable to map. Since the aws_iam_role_policy_attachment does not have any description argument I used it just for the map key.

![image](https://github.com/schubergphilis/terraform-aws-mcaf-role/assets/39799163/4bbc0ea8-3673-40f5-b326-482cd2ea60e2)
