### PR TITLE
fix: the added cross variable validation in v0.5.0 needs terraform v1.9>

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Terraform module that creates an IAM role.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 
 ## Providers

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -5,5 +5,5 @@ terraform {
       version = ">= 4.0.0"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -5,5 +5,5 @@ terraform {
       version = ">= 4.0.0"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
 }


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
the added cross variable validation in v0.5.0 needs terraform v1.9>

**:rocket: Motivation**
using a version lower than v1.9 is not possible anymore and leads to errors: https://github.com/schubergphilis/terraform-aws-mcaf-role/issues/19

**:pencil: Additional Information**
n/a