### PR TITLE
fix: removing count to ensure predictable plan-time evaluation and avoid dependency on role_policy resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ No modules.
 | [aws_iam_role_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.empty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 


### PR DESCRIPTION
:hammer_and_wrench: Summary
Remove count usage to avoid plan-time failures in nested module contexts.

:rocket: Motivation
Terraform plans were failing due to dynamic count evaluation in nested modules, particularly when create_policy depended on values not known until apply. This caused issues when composing higher-level modules.

:pencil: Additional Information
When create_policy is false or no valid role_policy is provided, we now attach a minimal IAM policy with an empty Statement array ("Statement": []). This is a valid, non-functional policy that grants no permissions, but allows the aws_iam_role_policy resource to be created consistently without introducing conditional logic using count or for_each.

IAM accepts this policy without errors. Functionally, the role behaves as if the inline policy does not exist, unless other attached policies (managed or inline) define permissions. This change ensures plan-time stability and avoids resource creation ambiguity in complex module hierarchies.