### PR TITLE
fix: removing count to ensure predictable plan-time evaluation and avoid dependency on role_policy resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ No modules.
 | [aws_iam_role_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.empty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 


### PR DESCRIPTION
🛠️ Summary
Simplified the way inline IAM policies are handled by removing count logic and making the behavior more predictable during terraform plan when using nested module hierarchies.

🚀 Motivation
In some cases, Terraform was failing during the plan phase because it couldn’t decide whether to create the inline IAM policy. This typically happened when create_policy depended on a value that wasn’t known until apply (like a computed role_policy). That made the module unreliable when reused inside other modules.

📝 Additional Information
The aws_iam_role_policy resource is now always created, no more conditional count or for_each.
If create_policy is false (or no real policy is provided), we attach a minimal, empty IAM policy.
This keeps AWS happy but doesn’t grant any permissions.
We also adjust the policy name depending on the context to avoid any naming collision with an existing policy:
- If we're creating a real policy: MyRolePolicy
- If it's an empty one: MyRole-empty-policy

This ensures Terraform always behaves the same way at plan time, avoiding surprises and errors — especially when using the module inside other modules.